### PR TITLE
Close pseudo-selectors that take classes as arguments (like :not()) in transformed css

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 #gulp-winify changelog
 
+
+##0.1.1 (01/11/16)
+
+###Close parentheses of pseudo-selectors that take classes as parameters
+
+- Refactor splitting the css ast selector string into individual classes/ids
+- Update Readme
+
+
 ##0.1 (01/11/16)
 
 ###Initial Release

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To this:
 <div class="billing-address__input ¢ selected ♥">...</div>
 ```
 
-##Usage:
+##Install:
 
 To install, type `npm install --save gulp-winify`
 
@@ -116,7 +116,7 @@ Using JavaScript's document.registerElement to let custom minified tags replace 
 
 
 ##Contributing:  
-Feel free to make a pull request, any help is welcome
+Feel free to fork and make a pull request, any help is welcome
  
 
 ##License  

--- a/lib/processors.js
+++ b/lib/processors.js
@@ -126,7 +126,7 @@ function processCSSRules( rules) {
       childRules = childRules.concat( rule.rules )
     }
 
-    if ( rule.selectors )   iterateCSSSelectors( rule )
+    if ( rule.selectors )  iterateCSSSelectors( rule )
   }
 
   if ( childRules.length ) processCSSRules( childRules )
@@ -135,22 +135,23 @@ function processCSSRules( rules) {
 
 function iterateCSSSelectors( rule ) {
 
-  let separatedSelectors, prefix
+  let separatedSelectors, prefix, newSelector
 
   rule.selectors.forEach( ( selectors, i ) => {
 
-    separatedSelectors = selectors.split( /(?=\.)|(?=#)|(?=\[)|(?=\:)|(?=\~)|\s+/gm ).slice()
+
+    //if (selectors.indexOf(':not') !== -1) console.log(rule);
+
+    separatedSelectors = selectors.split( /(?=[\.#\[\:\~\)])|\s+/gm ).slice()
     separatedSelectors.forEach( ( selector ) => {
 
       prefix = selector.match( /^\W/g ) || ['']
       prefix = prefix[0]
 
-      if ( isValidPrefix( prefix ) ) { 
+      if ( isValidPrefix( prefix ) ) {
+        newSelector = createMinifiedSelector( prefix, selector )
 
-        createMinifiedSelector( prefix, selector )
-
-        rule.selectors[i] = rule.selectors[i].replace( selector, getMinifiedSelector( selector ) )
-
+        rule.selectors[i] = rule.selectors[i].replace( selector, newSelector )
       }
 
     })

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gulp-winify",
   "description": "Aggressive CSS/HTML minifier",
   "author": "Adam Chamberland",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "index.js",
   "keywords": [
     "gulpplugin"


### PR DESCRIPTION
CSS pseudo-selectors that take classes as arguments are getting their closing parentheses stripped out of the transformed result. This commit adds parentheses to the set of characters to split classes from their selector string by, leaving the closing parentheses unchanged.

Also
- Refactor RegEx for parsing classes from selectors.
- Update Readme
- Bump version to 0.1.1
