### PR TITLE
Prevent ID tags from being minified unless user setting forces it on.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 #gulp-winify changelog
 
 
+##0.1.2 (01/11/16)
+
+###Allow ID tags to be minified by setting `minifyIds` to true in the gulpfile's winify call
+
+Also:
+- Fix issues preventing user settings from being applied in builds
+- Prevent '.' being prepended to classes in the html file output
+
+
 ##0.1.1 (01/11/16)
 
 ###Close parentheses of pseudo-selectors that take classes as parameters

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This project is still in early stages so make sure to test before making product
 
 ##How it works:  
 
-The selectors in your CSS get minified. Each class and id are reduced to one unique UTF-8 character, which is added as a separate class to the original element in your HTML. None of the original HTML is replaced, so there are no side effects.
+The selectors in your CSS get minified. Each class (and optionally, id) are reduced to one unique UTF-8 character, which is added as a separate class to the original element in your HTML. None of the original HTML is replaced, so there are no side effects.
 
 
 ### Example:
@@ -47,8 +47,8 @@ var cssnano = require('gulp-cssnano');
 
 gulp.task('default', function(){
   return gulp.src( ['./src/*.css', './src/*.html'] )
+    .pipe( winify() )
     .pipe( cssnano() )
-  	.pipe( winify() )
     .pipe( gulp.dest('./dist') ); 
 });
 ```
@@ -71,8 +71,9 @@ gulp.task('css', function(){
 ###Options:
 An options object can be passed into your gulpfile's call to winify(). Options will usually be for enabling features in development, or features that might be too aggressive for some projects.
 
-`experimental: true`: Turn on experimental features currently in development. (Default: false)  
+`experimental: true`: Turn on experimental features currently in development. (Default: false) 
 `alphabeticSelectors: true`: Start minified class characters at alphabetic letters [A-z]. (Default: false)
+`minifyIds: true`: Minify ids. (Currently will add a second id until class/id replacement is developed. Two ids on one element isn't valid in HTML and will cause browser issues until then). (Default: false)
 
 Example gulpfile call:  
 `.pipe( winify({ experimental: true }) )`

--- a/lib/characters.js
+++ b/lib/characters.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const config = require( './config.js')
-
 const BASIC_LATIN_START = 65
     , PUNCTUATION_START = 91
     , PUNCTUATION_END   = 97
@@ -42,7 +40,7 @@ let character = {
   
   },
 
-  init() {
+  init( config ) {
 
     this.startCharcode = config.alphabeticSelectors === true ? BASIC_LATIN_START : EXTENDED_START
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -2,6 +2,8 @@
 
 let selectors  = require( './selectors.js' )
 let characters = require( './characters.js')
+let processors = require( './processors.js')
+let validation = require( './validation.js')
 
 
 let config = {
@@ -9,13 +11,17 @@ let config = {
   defaults: {
     alphabeticSelectors: false,
     experimental: false,
+    minifyIds: false
   },
 
   init( options ) {
-    applyOptions(options)
+    options = applyOptions(options)
 
-    selectors.init();
-    characters.init();
+    selectors .init(options);
+    characters.init(options);
+    processors.init(options);
+    validation.init(options);
+
   }
 
 }
@@ -23,7 +29,7 @@ let config = {
 
 function applyOptions( options ) {
 
-  Object.assign( config, config.defaults, options )
+  return Object.assign( {}, config.defaults, options )
 
 }
 

--- a/lib/processors.js
+++ b/lib/processors.js
@@ -6,7 +6,7 @@ const acorn = require( 'acorn')
 const walk = require( 'walk-ast')
 const escodegen = require( 'escodegen')
  
-const config = require( './config.js' )
+let config = require( './config.js' )
 
 let selectors              = require( './selectors.js')
   , createMinifiedSelector = selectors.createMinifiedSelector
@@ -24,10 +24,6 @@ let processors = {
   processHTML( data, _charset ){
 
     let $ = cheerio.load( data)
-    let insertSelector = !!config.experimental ? 
-      ( className) => className : 
-      ( className, original) => original + ' ' + className.slice(1)
-
 
     $('*').each( (i, $el) => {
 
@@ -48,11 +44,10 @@ let processors = {
 
           createMinifiedSelector( '.', '.' +  className )
 
-          $el.attribs.class = $el.attribs.class.replace( className, insertSelector( getMinifiedSelector('.' + className), '.' + className ) )
+          $el.attribs.class = $el.attribs.class.replace( className, this.insertSelector( getMinifiedSelector('.' + className), className ) )
 
         })
       }
-
 
       // Ids
 
@@ -62,7 +57,7 @@ let processors = {
 
           createMinifiedSelector( '#', id )
 
-          $el.attribs.id = $el.attribs.id.replace(id, insertSelector( getMinifiedSelector(id), id ) )
+          $el.attribs.id = $el.attribs.id.replace(id, this.insertSelector( getMinifiedSelector(id), id ) )
 
         })
       }
@@ -111,6 +106,13 @@ let processors = {
 
   
     return escodegen.generate( ast )
+  },
+
+  init(config) {
+
+    this.insertSelector = !!config.experimental ? 
+      ( className) => className : 
+      ( className, original) => original + ' ' + className.slice(1)
   }
 
 }
@@ -147,6 +149,7 @@ function iterateCSSSelectors( rule ) {
 
       prefix = selector.match( /^\W/g ) || ['']
       prefix = prefix[0]
+
 
       if ( isValidPrefix( prefix ) ) {
         newSelector = createMinifiedSelector( prefix, selector )

--- a/lib/selectors.js
+++ b/lib/selectors.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const config   = require( './config.js' )
 let characters = require( './characters.js')
 
 let minifiedSelectors = {}
@@ -8,10 +7,7 @@ let charcodes = {}
 
 let selectors = {
 
-  allowedSelectors: {
-    className: '.',
-    id: '#'
-  },
+  allowedSelectors: {},
 
   createMinifiedSelector( prefix, selector ) {
 
@@ -28,14 +24,17 @@ let selectors = {
 
   },
 
-  init() {
-
-    if ( config.experimental === true ) this.allowedSelectors.tag = ''
-
+  init( config ) {
+    setAllowedSelectors( config )
   }
   
 }
 
+function setAllowedSelectors( config ){
+  selectors.allowedSelectors.className = '.'
+  if ( config.experimental === true ) selectors.allowedSelectors.tag = '\w'
+  if ( config.minifyIds    === true ) selectors.allowedSelectors.id  = '#'
+}
 
 
 module.exports = selectors

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -1,14 +1,35 @@
 'use strict'
 
+let allowedSelectors = require('./selectors.js').allowedSelectors;
+
 let validation = {
 
+  prefixRegex: new RegExp(),
+
 	isAllowedTagName( name ) {
-	  return !name.match( /^html$|^head$|^body$|^link$|^script$|^style$|^meta$|^title$|^iframe$|^h.$|^.$|^map$|^canvas$|^area$|^img$/ig )
-	},
+
+	  return !name.match( /^.$|^html$|^head$|^body$|^link$|^script$|^style$|^meta$|^title$|^iframe$|^h.$|^map$|^canvas$|^area$|^img$/ig )
+	
+  },
 
 	isValidPrefix( prefix ) {
-	  return !!prefix.match( /[\.#]/ )
-	}
+	  return !!prefix.match( validation.prefixRegex )
+
+	},
+
+  init() {
+
+    //Todo: allowedSelectors.tag doesn have a regex match value
+    this.prefixRegex = new RegExp(
+      '['
+       + '\\' 
+       + (allowedSelectors.className||'')
+       + (allowedSelectors.id||'')
+       + (allowedSelectors.tag||'')
+    + ']'
+    ) 
+
+  }
 
 }
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gulp-winify",
   "description": "Aggressive CSS/HTML minifier",
   "author": "Adam Chamberland",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "main": "index.js",
   "keywords": [
     "gulpplugin"


### PR DESCRIPTION
Also fix issues preventing user settings from being applied, and prevent periods from being prepended to some classes in outputted HTML files
